### PR TITLE
[ADD] options --allways-create and --all-files

### DIFF
--- a/junit_conversor/__init__.py
+++ b/junit_conversor/__init__.py
@@ -1,11 +1,32 @@
 import xml.etree.cElementTree as ET
+import os
 import sys
 from collections import defaultdict
+import click
 
 
-def _parse(file_name):
+def _prepare_file_tree(path):
+    tree = defaultdict(list)
+
+    if not os.path.exists(path):
+        click.echo('Given file path does not exists. Using only files '
+                   'with errors from flake8 output.', err=True)
+        return tree
+
+    for (directory, _, files) in os.walk(path):
+        for f in files:
+            if f.endswith('.py'):
+                tree[os.path.join(directory, f)] = []
+
+    return tree
+
+
+def _parse(file_name, all_files_path=False):
     lines = tuple(open(file_name, 'r'))
     parsed = defaultdict(list)
+
+    if all_files_path:
+        parsed = _prepare_file_tree(all_files_path)
 
     for line in lines:
         splitted = line.split(":")
@@ -25,10 +46,10 @@ def _parse(file_name):
     return dict(parsed)
 
 
-def _convert(origin, destination):
-    parsed = _parse(origin)
+def _convert(origin, destination, allways_create=False, all_files_path=False):
+    parsed = _parse(origin, all_files_path=all_files_path)
 
-    if len(parsed) < 1:
+    if len(parsed) < 1 and not allways_create:
         return
 
     testsuite = ET.Element("testsuite")

--- a/junit_conversor/cli.py
+++ b/junit_conversor/cli.py
@@ -5,9 +5,14 @@ from . import _convert
 @click.command()
 @click.argument('source')
 @click.argument('destination')
-def conversion(source, destination):
+@click.option('--allways-create', '-c', is_flag=True,
+              help='Create a junit report file even if there are no errors.')
+@click.option('--all-files', '-a', help='Output all python files in output '
+                                        'file of given directory.')
+def conversion(source, destination, allways_create, all_files):
     """
     Converts a flake8 file to junit
     """
-    _convert(source, destination)
+    _convert(source, destination, allways_create=allways_create,
+             all_files_path=all_files)
     click.echo(click.style('Conversion done', fg='green'))


### PR DESCRIPTION
I added two option:

* With --allways-create or -c you can force to create an output file even if the source file is empty. We use the output file in atlassian bamboo and the tool complains about no found junit files. So even if all flake8 tests succeeded we want to have a junit file.

* With --all-files <dir> or -a <dir> you can add all python files from the given directory (recursively)  as test cases. So the tests cases are consistent and better for the history in external build tools.