### PR TITLE
Always create junit XML and exit clean

### DIFF
--- a/bin/flake8_junit
+++ b/bin/flake8_junit
@@ -5,7 +5,8 @@ from junit_conversor import _convert
 
 def main(flake8_file, destination_file):
     _convert(flake8_file, destination_file)
-    sys.exit("File %s was created successfully" % destination_file)
+    sys.stdout.write("File %s was created successfully" % destination_file)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/junit_conversor/__init__.py
+++ b/junit_conversor/__init__.py
@@ -32,20 +32,26 @@ def _convert(origin, destination):
     testsuite.attrib["errors"] = str(len(parsed))
     testsuite.attrib["failures"] = "0"
     testsuite.attrib["name"] = "flake8"
-    testsuite.attrib["tests"] = str(len(parsed))
+    testsuite.attrib["tests"] = str(len(parsed)) or "1"
     testsuite.attrib["time"] = "1"
 
-    for file_name, errors in parsed.items():
-        testcase = ET.SubElement(testsuite, "testcase", name=file_name)
+    if len(parsed) < 1:
+        testcase = ET.SubElement(testsuite, "testcase", name="Flake8Tests")
+    else:
+        for file_name, errors in parsed.items():
+            testcase = ET.SubElement(testsuite, "testcase", name=file_name)
 
-        for error in errors:
-            ET.SubElement(testcase, "failure", file=error['file'], line=error['line'], col=error['col'],
-                          message=error['detail'], type="flake8 %s" % error['code']) \
-                          .text = "{0}:{1} {2}".format(error['line'], error['col'], error['detail'])
+            for error in errors:
+                ET.SubElement(testcase, "failure", file=error['file'],
+                              line=error['line'], col=error['col'],
+                              message=error['detail'],
+                              type="flake8 %s" % error['code']) \
+                    .text = "{0}:{1} {2}".format(error['line'],
+                                                 error['col'],
+                                                 error['detail'])
 
     tree = ET.ElementTree(testsuite)
     if (2, 6) == sys.version_info[:2]:  # py26
         tree.write(destination, encoding='utf-8')
     else:
         tree.write(destination, encoding='utf-8', xml_declaration=True)
-

--- a/junit_conversor/__init__.py
+++ b/junit_conversor/__init__.py
@@ -28,13 +28,10 @@ def _parse(file_name):
 def _convert(origin, destination):
     parsed = _parse(origin)
 
-    if len(parsed) < 1:
-        return
-
     testsuite = ET.Element("testsuite")
     testsuite.attrib["errors"] = str(len(parsed))
     testsuite.attrib["failures"] = "0"
-    testsuite.attrib["name"] = "flake8 failures"
+    testsuite.attrib["name"] = "flake8"
     testsuite.attrib["tests"] = str(len(parsed))
     testsuite.attrib["time"] = "1"
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,10 +80,6 @@ class ConvertTest(TestCase):
         self.assertFileExist(self.destination)
         self.assertXmlIsValid(self.destination)
 
-    def test_should_not_create_a_file_if_there_are_no_errors(self):
-        _convert(valid_flake8, self.destination)
-        self.assertFileDoesNotExist(self.destination)
-
 
 # class JunitConversorCliTest(TestCase):
 #     runner = CliRunner()


### PR DESCRIPTION
We are running Flake8 tests with Bamboo, when running the JUnit step of a plan, it expects an XML (even if the tests succeeded. In this pull request, I've modified it so it always outputs an XML, even if there are no failing tests.

Also, I made a small change in the exit-process. Previously it would always exit with exit code 1, while actually the process was successfully. It now prints the success-message and exits with code 0 afterwards.

(I'm an sysadmin, not a developer, so forgive me if I made a dirty mistake somewhere.)