### PR TITLE
Fix parsing of flake8 errors containing colons

### DIFF
--- a/junit_conversor/__init__.py
+++ b/junit_conversor/__init__.py
@@ -8,7 +8,7 @@ def _parse(file_name):
     parsed = defaultdict(list)
 
     for line in lines:
-        splitted = line.split(":")
+        splitted = line.split(":", 3)
 
         # Skip invalid lines
         if len(splitted) == 4:

--- a/tests/flake8_example_results/failed_flake8.txt
+++ b/tests/flake8_example_results/failed_flake8.txt
@@ -1,3 +1,4 @@
 tests/subject/__init__.py:1:1: F401 'os' imported but unused
 tests/subject/__init__.py:3:1: E302 expected 2 blank lines, found 1
 tests/subject/example.py:4:1: E302 expected 2 blank lines, found 1
+tests/subject/example.py:16:22: E203 whitespace before ':'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -45,6 +45,7 @@ class ParseTest(TestCase):
             ],
             "tests/subject/example.py": [
                 {"file": "tests/subject/example.py", "line": "4", "col": "1", "detail": "E302 expected 2 blank lines, found 1", "code": "E302"},
+                {"file": "tests/subject/example.py", "line": "16", "col": "22", "detail": "E203 whitespace before ':'", "code": "E203"},
             ]
         })
 


### PR DESCRIPTION
We encountered a case today where `flake8` was reporting problems but `flake8_junit`'s generated XML indicated that no tests had failed.  It turned out to be a problem with the way `flake8_junit` handles valid `flake8` error messages that contain colons.

The message in this case was:

```
tests/subject/example.py:16:22: E203 whitespace before ':'
```

This pull request includes a new test and a fix for this corner case.  Tests pass for me locally using `tox`.

Hope this helps!